### PR TITLE
chore: configure commitlint and husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit "$1"

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,23 @@
+/** @type {import('@commitlint/types').UserConfig} */
+const config = {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "chore",
+        "refactor",
+        "perf",
+        "test",
+        "ci",
+        "style",
+      ],
+    ],
+  },
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "prepare": "husky"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",


### PR DESCRIPTION
## Summary

- Adds commitlint with conventional config and project-specific type-enum
- Adds husky prepare script and commit-msg hook
- Empty pre-commit hook placeholder for future use

Closes #27