### PR TITLE
docs: readme setup skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Lately
 
-## Getting Started
+A self-hosted, single-user tumblelog. One column, chronological, yours.
 
-First, run the development server:
+## Local development
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
+npm run dev        # start dev server at http://localhost:3000
+npm test           # run unit tests (vitest)
+npm run test:e2e   # run e2e tests (playwright)
+npm run build      # production build
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+## Environment variables
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Copy `.env.local.example` to `.env.local` and fill in the values.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+| Variable | Required | Description |
+|---|---|---|
+| `SUPABASE_URL` | Yes | Supabase project URL |
+| `SUPABASE_ANON_KEY` | Yes | Supabase anon key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Yes | Server-only service role key, never exposed to browser |
+| `NEXT_PUBLIC_SUPABASE_URL` | Yes | Same as `SUPABASE_URL`, browser-exposed |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Yes | Same as `SUPABASE_ANON_KEY`, browser-exposed |
+| `TMDB_API_KEY` | Yes | TMDB read access token |
+| `LATELY_OWNER_EMAIL` | Yes | Owner email address; determines `isOwner` for admin UI |
+| `LATELY_SITE_TITLE` | Yes | Display name shown in the header |
+| `LATELY_SUBTITLE` | Yes | One-line subtitle shown next to the site title |
+| `LATELY_TIMEZONE` | Yes | Owner timezone, e.g. `America/New_York` |
+| `LATELY_SOCIAL_LINKS` | No | Comma-separated `label\|url` pairs, e.g. `GitHub\|https://github.com/you` |
+| `LATELY_ACCENT_COLOR` | No | Hex accent color, default `#0070f3` |
+| `NEXT_PUBLIC_BASE_URL` | Yes | Full deployment URL, e.g. `https://lately.example.com` |
 
-## Learn More
+## Deploy
 
-To learn more about Next.js, take a look at the following resources:
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/tommcfarlin/lately)
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Set all required environment variables in your Vercel project settings before deploying.


### PR DESCRIPTION
## Summary

- Documents all 13 env vars from spec section 12 in a table
- Documents local dev commands: dev, test, test:e2e, build
- Adds Vercel deploy button

Closes #32